### PR TITLE
Pass in column to vue editor adapter

### DIFF
--- a/src/vue-editor-adapter.tsx
+++ b/src/vue-editor-adapter.tsx
@@ -28,6 +28,7 @@ export default class VueEditorAdapter {
         return <span ref={(el) => {
           this.vueEl = vueTemplateConstructor(this.VueEditorConstructor, el as HTMLElement, {
             ...this.editCell,
+            column: this.column,
             save: this.save,
             close: this.close
         })}}/>;


### PR DESCRIPTION
We want to define a custom dropdown component, where the dropdown is filled with a dynamic list of options. The most logical place to pass the options through would be through the column definition. We were somewhat surprised that the column definition was not available in the component, and we saw it wasn't passed through (even though it was already available in the adapter). So hereby the fix that makes this use case work for us.